### PR TITLE
Add new filters tests

### DIFF
--- a/cypress/e2e/filters/filter-color.spec.cy.ts
+++ b/cypress/e2e/filters/filter-color.spec.cy.ts
@@ -1,0 +1,43 @@
+import { initial } from "lodash";
+
+describe("Filter Color", () => {
+  beforeEach(() => {
+    cy.visit(Cypress.env("baseUrl"));
+  });
+
+  it("should display the color filter correctly", () => {
+    cy.getByDataTest("filters-form-label").should("exist");
+    cy.getByDataTest("color-input").should("exist");
+  });
+
+  it("should filter by color correctly", () => {
+    const colorsToMatch = [
+      {
+        color: "#822017",
+        matchCount: 2,
+        photographersRegexp: /(Dagmara|Daria)\b/,
+      },
+      {
+        color: "#8897c0",
+        matchCount: 3,
+        photographersRegexp: /(Sunsetoned|başaran|Alina)\b/,
+      },
+    ];
+
+    colorsToMatch.forEach((color) => {
+      cy.getByDataTest("color-input")
+        .click()
+        .invoke("val", color.color)
+        .trigger("input");
+
+      cy.getByDataTest("photo-list-item").should(
+        "have.length",
+        color.matchCount
+      );
+
+      cy.getByDataTest("photographer-link")
+        .invoke("text")
+        .should("match", color.photographersRegexp);
+    });
+  });
+});

--- a/cypress/e2e/filters/filter-search.spec.cy.ts
+++ b/cypress/e2e/filters/filter-search.spec.cy.ts
@@ -1,0 +1,57 @@
+import { initial } from "lodash";
+
+describe("Filter Search", () => {
+  beforeEach(() => {
+    cy.visit(Cypress.env("baseUrl"));
+  });
+
+  it("should display the search filter correctly", () => {
+    cy.getByDataTest("filters-form-label").should("exist");
+    cy.getByDataTest("search-input").should("exist");
+  });
+
+  it("should apply the search filter when filled", () => {
+    // Testing cyrillic alphabet too
+    const PHOTOGRAPHERS = ["Regina", "Диана"];
+    let initialPhotoCount: number = 0;
+
+    for (const photographer of PHOTOGRAPHERS) {
+      cy.getByDataTest("photo-list-item")
+        .should("have.length.greaterThan", 0)
+        .then((photos) => {
+          initialPhotoCount = photos.length;
+          cy.getByDataTest("search-input").type(photographer);
+
+          cy.getByDataTest("photo-list-item").should(
+            "not.equal",
+            initialPhotoCount
+          );
+
+          cy.getByDataTest("photographer-link").should(
+            "include.text",
+            photographer
+          );
+        });
+      cy.get("#search-input").clear();
+    }
+  });
+
+  it("should apply the search filter when filled with invalid search", () => {
+    let initialPhotoCount: number = 0;
+    const SEARCH_STRING = "foo";
+
+    cy.getByDataTest("photo-list-item")
+      .should("have.length.greaterThan", 0)
+      .then((photos) => {
+        initialPhotoCount = photos.length;
+        cy.getByDataTest("search-input").type(SEARCH_STRING);
+
+        cy.getByDataTest("photo-list-item").should("not.exist");
+
+        cy.getByDataTest("empty-list").should(
+          "include.text",
+          "No photos match your search criteria"
+        );
+      });
+  });
+});

--- a/cypress/e2e/gallery/photo-details.spec.cy.ts
+++ b/cypress/e2e/gallery/photo-details.spec.cy.ts
@@ -1,0 +1,42 @@
+import { initial } from "lodash";
+
+describe("Photo Details", () => {
+  beforeEach(() => {
+    cy.visit(Cypress.env("baseUrl"));
+  });
+
+  it("should display some photos", () => {
+    cy.getByDataTest("photo-list-item").should("have.length.greaterThan", 0);
+  });
+
+  it("should display a photos details", () => {
+    cy.getByDataTest("search-input")
+      .type("Valera Evane")
+      .then((photos) => {
+        cy.getByDataTest("photo-list-item").should("have.length", 1);
+        cy.getByDataTest("photo-list-item")
+          .first()
+          .click()
+          .then((photo) => {
+            cy.getByDataTest("nav-back-link").should("exist");
+            cy.get("h1").contains(
+              "portrait of blonde woman wearing sunglasses "
+            );
+
+            cy.getByDataTest("photographer-name").should(
+              "include.text",
+              "Valera Evane"
+            );
+
+            cy.getByDataTest("nav-back-link")
+              .click()
+              .then((photos) => {
+                cy.getByDataTest("photo-list-item").should(
+                  "have.length.greaterThan",
+                  1
+                );
+              });
+          });
+      });
+  });
+});

--- a/cypress/e2e/gallery/photo-load-more.spec.cy.ts
+++ b/cypress/e2e/gallery/photo-load-more.spec.cy.ts
@@ -1,0 +1,29 @@
+import { initial } from "lodash";
+
+describe("Photo Load More button", () => {
+  beforeEach(() => {
+    cy.visit(Cypress.env("baseUrl"));
+  });
+
+  it("should display load more button", () => {
+    cy.getByDataTest("load-more-button").should("exist");
+  });
+
+  it("should display a photos details", () => {
+    let initialPhotoCount: number = 0;
+    cy.getByDataTest("photo-list-item")
+      .should("have.length.greaterThan", 0)
+      .then((photos) => {
+        initialPhotoCount = photos.length;
+
+        cy.getByDataTest("load-more-button").click();
+
+        cy.getByDataTest("photo-list-item")
+          .should("have.length.greaterThan", 0)
+          .then((photos) => {
+            // Using another assertion method than "should"
+            expect(photos.length).to.be.greaterThan(initialPhotoCount);
+          });
+      });
+  });
+});


### PR DESCRIPTION
I added few tests for the gallery page.
- Started with a simple one, some tests for the search filter, just to remind myself how Cypress works
- Then the color filter, to be honest I did it because I never tested such component, I was a bit curious
- Photo details, just to check that we're able to navigate to a photo details and go back to the main gallery
- Finally testing the Load more button, just to be sure that more photo can be loaded.

I assumed that I was aware of the dataset. I could have made the tests more autonomous but considering you assumed 1 hour was enough for this test I did not push too hard this way.